### PR TITLE
Change Dockerfile to build from Ubuntu 20.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 #ARG RELEASE=almalinux:8.8
 #ARG RELEASE=oraclelinux:8.8
 #ARG RELEASE=rockylinux:8.8
-ARG RELEASE=ubuntu:18.04
-#ARG RELEASE=ubuntu:20.04
+#ARG RELEASE=ubuntu:18.04
+ARG RELEASE=ubuntu:20.04
 
 # DO NOT EDIT BELOW THIS LINE
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You can then unpack this archive file and install/upgrade Zimbra in the usual ma
 
 A ```Dockerfile``` is provided to build the *builder image*, which can later be used to create a release.
 
-The default ```Dockerfile``` builds an image for ```Ubuntu 18.04```.  To build for other distributions, edit the ```Dockerfile``` and comment/uncomment the version you wish to build for.  An example is shown below:
+The default ```Dockerfile``` builds an image for ```Ubuntu 20.04```.  To build for other distributions, edit the ```Dockerfile``` and comment/uncomment the version you wish to build for.  An example is shown below:
 
 ```
 # Uncomment the distro that you wish to build for

--- a/zimbra-build-helper.sh
+++ b/zimbra-build-helper.sh
@@ -3,7 +3,7 @@
 ##################################
 # Zimbra Build Helper Script     #
 # Prepared By: Ian Walker        #
-# Version: 1.1.2                 #
+# Version: 1.1.3                 #
 #                                #
 # Supports:                      #
 #     AlmaLinux 8                #


### PR DESCRIPTION
Since Ubuntu 18.04 went EOL in May 2023, the default build for Dockerfile now defaults to Ubuntu 20.04.