### PR TITLE
Patch to remove libphp.so

### DIFF
--- a/patches/zimbra-aspell-httpd.conf.patch
+++ b/patches/zimbra-aspell-httpd.conf.patch
@@ -1,0 +1,11 @@
+--- zm-aspell/conf/httpd.conf	2024-04-02 15:53:01.039306751 +0200
++++ httpd.conf	2024-04-02 15:59:29.579428927 +0200
+@@ -145,7 +145,7 @@
+ LoadModule alias_module /opt/zimbra/common/lib/apache2/modules/mod_alias.so
+ #LoadModule rewrite_module /opt/zimbra/common/lib/apache2/modules/mod_rewrite.so
+ LoadModule mpm_event_module /opt/zimbra/common/lib/apache2/modules/mod_mpm_event.so
+-LoadModule php_module        /opt/zimbra/common/lib/apache2/modules/libphp.so
++#LoadModule php_module        /opt/zimbra/common/lib/apache2/modules/libphp.so
+ 
+ <IfModule unixd_module>
+ #

--- a/zimbra-build-helper.sh
+++ b/zimbra-build-helper.sh
@@ -204,6 +204,7 @@ build_zimbra() {
     cp patches/zimbra-jetty.xml.production.patch ${MAINDIR}/${PROJECTDIR}
     cp patches/zimbra-nginx.conf.main.template.patch ${MAINDIR}/${PROJECTDIR}
     cp patches/zimbra-utilfunc.sh.patch ${MAINDIR}/${PROJECTDIR}
+    cp patches/zimbra-aspell-httpd.conf.patch ${MAINDIR/${PROJECTDIR}
     cd ${MAINDIR}/${PROJECTDIR}
 
     # Patch Zimbra 9 to remove onlyoffice and fix nginx config
@@ -214,6 +215,14 @@ build_zimbra() {
         git clone https://github.com/zimbra/zm-nginx-conf
         patch ${MAINDIR}/${PROJECTDIR}/zm-jetty-conf/conf/jetty/jetty.xml.production zimbra-jetty.xml.production.patch
         patch ${MAINDIR}/${PROJECTDIR}/zm-nginx-conf/conf/nginx/nginx.conf.main.template zimbra-nginx.conf.main.template.patch
+    fi
+
+    # Patch Zimbra to remove libphp.so from zm-aspell/conf/httpd.conf for Zimbra 9.0.0 and Zimbra 10.0.x versions
+    # as they do not include PHP.
+    if [ "${ZIMBRA_VER}" == "9.0.0" ] || [[ "${ZIMBRA_VER}" == "10.0"* ]]
+    then
+        git clone https://github.com/zimbra/zm-aspell
+        patch ${MAINDIR}/${PROJECTDIR}/zm-aspell/conf/httpd.conf zimbra-aspell-httpd.conf.patch
     fi
 
     # Clone zm-build repository

--- a/zimbra-build-helper.sh
+++ b/zimbra-build-helper.sh
@@ -204,7 +204,7 @@ build_zimbra() {
     cp patches/zimbra-jetty.xml.production.patch ${MAINDIR}/${PROJECTDIR}
     cp patches/zimbra-nginx.conf.main.template.patch ${MAINDIR}/${PROJECTDIR}
     cp patches/zimbra-utilfunc.sh.patch ${MAINDIR}/${PROJECTDIR}
-    cp patches/zimbra-aspell-httpd.conf.patch ${MAINDIR/${PROJECTDIR}
+    cp patches/zimbra-aspell-httpd.conf.patch ${MAINDIR}/${PROJECTDIR}
     cd ${MAINDIR}/${PROJECTDIR}
 
     # Patch Zimbra 9 to remove onlyoffice and fix nginx config


### PR DESCRIPTION
Required for building Zimbra 9.0.0 and 10.0.x from develop branch.