### PR TITLE
Fixes to OS detection

### DIFF
--- a/zimbra-build-helper.sh
+++ b/zimbra-build-helper.sh
@@ -3,7 +3,7 @@
 ##################################
 # Zimbra Build Helper Script     #
 # Prepared By: Ian Walker        #
-# Version: 1.1.6                 #
+# Version: 1.1.7                 #
 #                                #
 # Supports:                      #
 #     AlmaLinux 8                #

--- a/zimbra-build-helper.sh
+++ b/zimbra-build-helper.sh
@@ -128,16 +128,20 @@ el8_pkg_install() {
 
 # Installs dependencies for EL9
 el9_pkg_install() {
-    if [ "${DISTRIB_RELEASE}" == "9" ] && [ "${DISTRIB_ID}" == "RedHatEnterprise" ]
-    then
-        sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
-    else
-        sudo dnf install -y dnf-plugins-core
-        sudo dnf config-manager --set-enabled crb
-    fi
-    sudo dnf group install -y "Development Tools"
-    sudo dnf install -y javapackages-tools
-    sudo dnf install -y java-1.8.0-openjdk gcc-c++ ant-junit ruby git maven cpan wget rpm-build createrepo rsync
+    echo -e "\nThis function is not ready/supported yet!"
+    echo -e "It requires Zimbra supporting EL9 distros first!\n"
+    exit 1
+
+    #if [ "${DISTRIB_RELEASE}" == "9" ] && [ "${DISTRIB_ID}" == "RedHatEnterprise" ]
+    #then
+    #    sudo subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
+    #else
+    #    sudo dnf install -y dnf-plugins-core
+    #    sudo dnf config-manager --set-enabled crb
+    #fi
+    #sudo dnf group install -y "Development Tools"
+    #sudo dnf install -y javapackages-tools
+    #sudo dnf install -y java-1.8.0-openjdk gcc-c++ ant-junit ruby git maven cpan wget rpm-build createrepo rsync
 }
 
 # Installs dependencies for OEL8


### PR DESCRIPTION
Fixes to OS detection as it wasn't working 100% as intended.  This wasn't noticeable until adding potential future support for installing dependencies for EL9 distros, and worked albeit not as it should have done.  This has now been addressed, and so works as it should have done in the beginning.

Function for installing EL9 dependencies has been added, although doesn't do anything just yet, and the dependencies need to be checked/verified as and when Synacor release Zimbra for EL9 distros.  Until this time, it's mostly considered as a placeholder for future use.  All that it currently does is outputs text that the function is not currently supported until Zimbra release for EL9.

Since current building relies on OpenJDK 8, it is most likely for EL9, building will utilise different JDK versions, as well as other dependency versions for ant, maven, etc.  But that's purely speculation at least until we see Zimbra supporting EL9.