### PR TITLE
Set umask to 0022 temporarily for build process

### DIFF
--- a/zimbra-build-helper.sh
+++ b/zimbra-build-helper.sh
@@ -162,6 +162,9 @@ build_zimbra() {
     # Get current userid - we need this if using sudo to fix directory permissions
     USERID=`echo ${USER}`
 
+    # Configure umask to ensure successful builds
+    umask 0022
+
     # Check if ${MAINDIR} exists, if not create it and set permissions
     if [ -d "${MAINDIR}" ]
     then


### PR DESCRIPTION
Fixes what was brought up in this discussion: https://github.com/ianw1974/zimbra-build-scripts/discussions/119

When building Zimbra on a machine that has had the umask changed, it can cause problems.  In our instance it was set to 0027 which caused serious failures with the install/upgrade of the build.  The build scripts resets it temporarily to a sane value so that builds can be made without any issues introduced.